### PR TITLE
Add circleback component for earmarking items to revisit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,14 @@ code-daily ideas list [--json] [--status TEXT]
 code-daily ideas add CONTENT [--json]
 code-daily ideas promote IDEA_ID [--json]
 code-daily ideas sync [--json]
+code-daily circleback add CONTENT [--kind TEXT] [--priority TEXT] [--date TEXT] [--note TEXT] [--json]
+code-daily circleback list [--json] [--status TEXT] [--kind TEXT]
+code-daily circleback due [--json]
+code-daily circleback done ITEM_ID [--json]
+code-daily circleback drop ITEM_ID [--json]
+code-daily circleback snooze ITEM_ID DATE [--json]
+code-daily circleback promote-to-issue ITEM_ID [--repo TEXT] [--json]
+code-daily circleback context [--json]
 code-daily quests list [--json] [--status TEXT] [--limit INT]
 code-daily quests add TITLE [--json] [--description TEXT]
 code-daily quests accept QUEST_ID [--json]
@@ -204,6 +212,50 @@ Returns a dict with `audit_path`, `audit_absolute_path` (paste-friendly),
 `linked_projects` (everything backlinked this run), and `new_stubs` (hubs
 created this run — surface these to the user so they know what's new).
 Logic lives in `src/codebase_audit.py`.
+
+## Circle-Back: Earmarking Items to Revisit
+
+`code-daily circleback` is a lightweight backlog for things you want to come
+back to but can't act on right now — work you started and mean to continue,
+new project ideas worth retaining, or anything surfaced during a
+`/newsandideas` run that deserves more than a fleeting mention. It is
+deliberately distinct from its two neighbours:
+
+- **`quests`** is the prioritized *work queue* fed by automated discovery sources.
+- **`ideas`** is the IDEAS.md-backed running list of coding ideas.
+
+Circle-back adds two things neither has: an optional **snooze-until date**
+(`circle_back_date`) so an item stays quiet until it's due, and an explicit
+**priority** (`high`/`medium`/`low`) that signals to the agent what *you* think
+is important. Each item has a **kind** (`continue`, `project`, or `idea`) and a
+lifecycle of `open → done | dropped | promoted`.
+
+Items live in the `circleback_items` table; logic is in `src/circleback.py`
+(`CircleBackManager`). `circleback add` dedupes on `(source, source_ref)` so
+automated capture is safe to re-run. `circleback due` shows only items that are
+actionable now (undated, or past their snooze date); the rest stay hidden until
+they come due. `circleback promote-to-issue` creates a real GitHub issue via
+`gh issue create` (see `gh_issues.create_issue`), records the URL, and marks the
+item `promoted` — the bridge for when an earmark is finally ready to act on.
+
+### newsandideas integration
+
+The nightly `/newsandideas` pipeline should bracket its run with circle-back:
+
+1. **Start of run — load priorities.** Run `code-daily circleback context --json`
+   and feed the result to the agent as "what the user has already flagged as
+   important." The payload groups due items by kind, counts high-priority items,
+   and reports how many are still snoozed, so new suggestions can defer to or
+   build on the existing backlog instead of duplicating it.
+2. **End of run — capture overflow.** When a session surfaces more good work
+   than fits in one day, earmark the rest rather than dropping it:
+   `code-daily circleback add "<thing>" --kind <continue|project|idea> --priority high [--date YYYY-MM-DD]`.
+   Use `--source newsandideas` style refs only via the Python API
+   (`CircleBackManager.add(..., source="newsandideas", source_ref=...)`) when you
+   need dedup across runs.
+
+This closes the loop: each run reads back the priorities the user set, and the
+overflow from a run becomes the seed for the next one.
 
 ## Agent Workflow: Themed News Digest
 

--- a/src/circleback.py
+++ b/src/circleback.py
@@ -1,0 +1,265 @@
+"""
+Circle-back: earmark items to revisit later.
+
+A lightweight backlog for things you want to come back to but can't (or don't
+want to) act on right now — work you started and mean to continue, new project
+ideas worth retaining, or anything surfaced during a `/newsandideas` run that's
+worth more than a fleeting mention.
+
+It is deliberately distinct from the two neighbouring systems:
+
+* ``quests`` is the *prioritized work queue* fed by automated discovery sources.
+* ``ideas`` is the IDEAS.md-backed running list of coding ideas.
+
+Circle-back items add two things neither has: an optional **snooze-until date**
+(``circle_back_date``) so an item stays quiet until it's due, and an explicit
+**priority** that signals to the agent what you think is important. Items can be
+promoted into a real GitHub issue once they're ready to act on.
+"""
+
+from datetime import date, datetime
+
+from src.storage import CommitStorage
+
+# Kinds map to the three buckets the feature is for.
+VALID_KINDS = ("continue", "project", "idea")
+DEFAULT_KIND = "idea"
+
+# Priority is stored as an int (1 = high) so it sorts naturally, but exposed to
+# humans as words.
+PRIORITY_BY_NAME = {"high": 1, "medium": 2, "low": 3}
+PRIORITY_NAME = {1: "high", 2: "medium", 3: "low"}
+DEFAULT_PRIORITY = 2
+
+VALID_STATUSES = ("open", "done", "promoted", "dropped")
+
+
+class CircleBackError(ValueError):
+    """Raised when a circle-back item is created/updated with invalid input."""
+
+
+def parse_priority(value) -> int:
+    """Normalise a priority given as a word ('high') or int (1) to an int.
+
+    Raises CircleBackError on anything unrecognised.
+    """
+    if value is None:
+        return DEFAULT_PRIORITY
+    if isinstance(value, int):
+        if value in PRIORITY_NAME:
+            return value
+        raise CircleBackError(f"priority must be 1-3, got {value}")
+    text = str(value).strip().lower()
+    if text in PRIORITY_BY_NAME:
+        return PRIORITY_BY_NAME[text]
+    if text in {"1", "2", "3"}:
+        return int(text)
+    raise CircleBackError(
+        f"priority must be one of high/medium/low or 1-3, got {value!r}"
+    )
+
+
+def _validate_kind(kind: str) -> str:
+    kind = (kind or DEFAULT_KIND).strip().lower()
+    if kind not in VALID_KINDS:
+        raise CircleBackError(
+            f"kind must be one of {', '.join(VALID_KINDS)}, got {kind!r}"
+        )
+    return kind
+
+
+def _validate_date(value: str | None) -> str | None:
+    if not value:
+        return None
+    value = value.strip()
+    try:
+        datetime.strptime(value, "%Y-%m-%d")
+    except ValueError as exc:
+        raise CircleBackError(
+            f"circle_back_date must be YYYY-MM-DD, got {value!r}"
+        ) from exc
+    return value
+
+
+def _decorate(item: dict) -> dict:
+    """Add human-friendly derived fields to a raw item dict."""
+    if item is None:
+        return item
+    item = dict(item)
+    item["priority_label"] = PRIORITY_NAME.get(item.get("priority"), "medium")
+    return item
+
+
+class CircleBackManager:
+    """Operations over the circle-back backlog."""
+
+    def __init__(self, storage: CommitStorage | None = None):
+        self.storage = storage or CommitStorage()
+
+    # -- create / mutate ---------------------------------------------------
+
+    def add(
+        self,
+        content: str,
+        kind: str = DEFAULT_KIND,
+        priority=DEFAULT_PRIORITY,
+        circle_back_date: str | None = None,
+        note: str | None = None,
+        source: str = "manual",
+        source_ref: str | None = None,
+    ) -> dict:
+        """Add an item to the backlog. Deduplicates on (source, source_ref).
+
+        Returns the created (or pre-existing, for a duplicate) item dict.
+        """
+        content = (content or "").strip()
+        if not content:
+            raise CircleBackError("content must not be empty")
+
+        kind = _validate_kind(kind)
+        priority_int = parse_priority(priority)
+        circle_back_date = _validate_date(circle_back_date)
+
+        if source_ref and self.storage.circleback_exists_by_source_ref(
+            source, source_ref
+        ):
+            # Return the existing item rather than creating a duplicate.
+            for existing in self.storage.get_circleback_items():
+                if existing.get("source") == source and existing.get(
+                    "source_ref"
+                ) == source_ref:
+                    return _decorate(existing)
+
+        item_id = self.storage.create_circleback_item(
+            content=content,
+            kind=kind,
+            priority=priority_int,
+            circle_back_date=circle_back_date,
+            note=note,
+            source=source,
+            source_ref=source_ref,
+        )
+        return _decorate(self.storage.get_circleback_item(item_id))
+
+    def mark_done(self, item_id: int) -> bool:
+        return self.storage.update_circleback_status(item_id, "done")
+
+    def drop(self, item_id: int) -> bool:
+        return self.storage.update_circleback_status(item_id, "dropped")
+
+    def snooze(self, item_id: int, circle_back_date: str) -> bool:
+        """Set/replace the snooze-until date on an item."""
+        circle_back_date = _validate_date(circle_back_date)
+        return self.storage.update_circleback_fields(
+            item_id, circle_back_date=circle_back_date or ""
+        )
+
+    def set_priority(self, item_id: int, priority) -> bool:
+        return self.storage.update_circleback_fields(
+            item_id, priority=parse_priority(priority)
+        )
+
+    # -- read --------------------------------------------------------------
+
+    def list_items(
+        self, status: str | None = "open", kind: str | None = None
+    ) -> list[dict]:
+        items = self.storage.get_circleback_items(status=status, kind=kind)
+        return [_decorate(i) for i in items]
+
+    def get(self, item_id: int) -> dict | None:
+        return _decorate(self.storage.get_circleback_item(item_id))
+
+    def due_items(self, today: date | None = None) -> list[dict]:
+        """Open items that are due now: undated, or dated on/before today.
+
+        These are the items worth surfacing — the rest are still snoozed.
+        """
+        today = today or date.today()
+        cutoff = today.isoformat()
+        due = []
+        for item in self.list_items(status="open"):
+            cbd = item.get("circle_back_date")
+            if not cbd or cbd <= cutoff:
+                due.append(item)
+        return due
+
+    def upcoming_items(self, today: date | None = None) -> list[dict]:
+        """Open items still snoozed for a future date."""
+        today = today or date.today()
+        cutoff = today.isoformat()
+        return [
+            item
+            for item in self.list_items(status="open")
+            if item.get("circle_back_date") and item["circle_back_date"] > cutoff
+        ]
+
+    # -- GitHub bridge -----------------------------------------------------
+
+    def promote_to_issue(self, item_id: int, repo: str | None = None) -> dict:
+        """Create a GitHub issue from an item and mark it 'promoted'.
+
+        Returns a result dict: {"ok": bool, "item": ..., "issue_url"/"error": ...}.
+        """
+        from src.gh_issues import create_issue
+
+        item = self.storage.get_circleback_item(item_id)
+        if not item:
+            return {"ok": False, "error": f"circle-back item {item_id} not found"}
+
+        body_lines = []
+        if item.get("note"):
+            body_lines.append(item["note"])
+        meta = (
+            f"\n\n---\n_Earmarked via code-daily circle-back "
+            f"(kind: {item.get('kind')}, priority: "
+            f"{PRIORITY_NAME.get(item.get('priority'), 'medium')})._"
+        )
+        body = ("\n".join(body_lines) + meta).strip()
+
+        result = create_issue(title=item["content"], body=body, repo=repo)
+        if not result.get("created"):
+            return {"ok": False, "error": result.get("error", "issue creation failed")}
+
+        url = result.get("url", "")
+        self.storage.set_circleback_issue(item_id, url)
+        return {
+            "ok": True,
+            "issue_url": url,
+            "item": _decorate(self.storage.get_circleback_item(item_id)),
+        }
+
+    # -- agent surfacing ---------------------------------------------------
+
+    def build_agent_context(self, today: date | None = None) -> dict:
+        """Structured context for the /newsandideas pipeline.
+
+        Surfaces the due backlog grouped by kind plus a count of what's still
+        snoozed, so the agent knows what the user has flagged as important
+        before proposing new work.
+        """
+        due = self.due_items(today=today)
+        by_kind: dict[str, list[dict]] = {k: [] for k in VALID_KINDS}
+        for item in due:
+            by_kind.setdefault(item.get("kind", DEFAULT_KIND), []).append(item)
+
+        upcoming = self.upcoming_items(today=today)
+        return {
+            "due": due,
+            "due_count": len(due),
+            "by_kind": by_kind,
+            "upcoming_count": len(upcoming),
+            "summary": self._summary_line(due, upcoming),
+        }
+
+    @staticmethod
+    def _summary_line(due: list[dict], upcoming: list[dict]) -> str:
+        if not due and not upcoming:
+            return "No circle-back items flagged."
+        high = sum(1 for i in due if i.get("priority") == 1)
+        parts = [f"{len(due)} item(s) to circle back to"]
+        if high:
+            parts.append(f"{high} high-priority")
+        if upcoming:
+            parts.append(f"{len(upcoming)} still snoozed")
+        return ", ".join(parts) + "."

--- a/src/gh_issues.py
+++ b/src/gh_issues.py
@@ -104,6 +104,53 @@ def search_issues(query: str, limit: int = 20) -> list[GhIssue]:
     return _run_gh(cmd)
 
 
+def create_issue(
+    title: str,
+    body: str = "",
+    repo: str | None = None,
+    labels: list[str] | None = None,
+) -> dict:
+    """Create a GitHub issue via the `gh` CLI.
+
+    Args:
+        title: Issue title.
+        body: Issue body (markdown).
+        repo: Target repo (owner/name). Defaults to the repo in the cwd.
+        labels: Optional labels to apply.
+
+    Returns:
+        dict with 'created' bool, and on success 'url' (the new issue URL),
+        or on failure 'error' with a message.
+    """
+    cmd = ["gh", "issue", "create", "--title", title, "--body", body]
+    if repo:
+        cmd.extend(["-R", repo])
+    if labels:
+        cmd.extend(["--label", ",".join(labels)])
+
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=30
+        )
+    except FileNotFoundError:
+        return {
+            "created": False,
+            "error": "gh CLI not found. Install from https://cli.github.com/",
+        }
+    except subprocess.TimeoutExpired:
+        return {"created": False, "error": "gh issue create timed out"}
+
+    if result.returncode != 0:
+        return {
+            "created": False,
+            "error": result.stderr.strip() or "gh issue create failed",
+        }
+
+    # gh prints the new issue URL to stdout.
+    url = result.stdout.strip().splitlines()[-1].strip() if result.stdout.strip() else ""
+    return {"created": True, "url": url}
+
+
 def _run_gh(cmd: list[str]) -> list[GhIssue]:
     """Run a gh command and parse the JSON output into GhIssue objects."""
     try:

--- a/src/storage.py
+++ b/src/storage.py
@@ -170,6 +170,33 @@ class CommitStorage:
             )
         """)
         conn.execute("""
+            CREATE TABLE IF NOT EXISTS circleback_items (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                content TEXT NOT NULL,
+                note TEXT,
+                kind TEXT DEFAULT 'idea',
+                priority INTEGER DEFAULT 2,
+                circle_back_date TEXT,
+                status TEXT DEFAULT 'open',
+                source TEXT DEFAULT 'manual',
+                source_ref TEXT,
+                issue_url TEXT,
+                created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+        conn.execute("""
+            CREATE INDEX IF NOT EXISTS idx_circleback_status ON circleback_items(status)
+        """)
+        conn.execute("""
+            CREATE INDEX IF NOT EXISTS idx_circleback_date
+            ON circleback_items(circle_back_date)
+        """)
+        conn.execute("""
+            CREATE INDEX IF NOT EXISTS idx_circleback_source_ref
+            ON circleback_items(source, source_ref)
+        """)
+        conn.execute("""
             CREATE TABLE IF NOT EXISTS external_cache (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 cache_key TEXT UNIQUE NOT NULL,
@@ -803,6 +830,185 @@ class CommitStorage:
         """
         conn = self._get_connection()
         cursor = conn.execute("DELETE FROM ideas WHERE id = ?", (idea_id,))
+        self._commit_and_sync(conn)
+        return cursor.rowcount > 0
+
+    # Circle-back methods
+    def create_circleback_item(
+        self,
+        content: str,
+        kind: str = "idea",
+        priority: int = 2,
+        circle_back_date: str | None = None,
+        note: str | None = None,
+        source: str = "manual",
+        source_ref: str | None = None,
+    ) -> int:
+        """
+        Create a new circle-back item (an earmarked thing to revisit later).
+
+        Args:
+            content: Short description of what to circle back to.
+            kind: One of 'continue' (work started), 'project' (new project), 'idea'.
+            priority: 1 (high), 2 (medium), 3 (low). Signals importance to the agent.
+            circle_back_date: Optional YYYY-MM-DD snooze-until date.
+            note: Optional longer context/note.
+            source: Where it came from ('manual', 'newsandideas', etc.).
+            source_ref: Reference for deduplication of synced sources.
+
+        Returns:
+            ID of the created item.
+        """
+        conn = self._get_connection()
+        cursor = conn.execute(
+            """
+            INSERT INTO circleback_items
+                (content, note, kind, priority, circle_back_date, source, source_ref)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (content, note, kind, priority, circle_back_date, source, source_ref),
+        )
+        self._commit_and_sync(conn)
+        return cursor.lastrowid
+
+    def get_circleback_items(
+        self, status: str | None = None, kind: str | None = None
+    ) -> list[dict]:
+        """
+        Get circle-back items, optionally filtered by status and/or kind.
+
+        Items are ordered so the most pressing surface first: by priority
+        ascending (1 = high) then by circle_back_date (soonest first, undated
+        last) then by recency.
+
+        Args:
+            status: Filter by status ('open', 'done', 'promoted', 'dropped').
+            kind: Filter by kind ('continue', 'project', 'idea').
+
+        Returns:
+            List of circle-back item dictionaries.
+        """
+        conn = self._get_connection()
+        query = "SELECT * FROM circleback_items"
+        clauses: list[str] = []
+        params: list = []
+
+        if status:
+            clauses.append("status = ?")
+            params.append(status)
+        if kind:
+            clauses.append("kind = ?")
+            params.append(kind)
+        if clauses:
+            query += " WHERE " + " AND ".join(clauses)
+
+        # NULL dates sort last; SQLite sorts NULL first by default, so coalesce.
+        query += (
+            " ORDER BY priority ASC,"
+            " COALESCE(circle_back_date, '9999-12-31') ASC,"
+            " created_at DESC"
+        )
+
+        cursor = conn.execute(query, params)
+        return self._fetchall_as_dicts(cursor)
+
+    def get_circleback_item(self, item_id: int) -> dict | None:
+        """Get a single circle-back item by ID, or None if not found."""
+        conn = self._get_connection()
+        cursor = conn.execute(
+            "SELECT * FROM circleback_items WHERE id = ?",
+            (item_id,),
+        )
+        return self._fetchone_as_dict(cursor)
+
+    def update_circleback_status(self, item_id: int, status: str) -> bool:
+        """Update a circle-back item's status. Returns True if a row changed."""
+        conn = self._get_connection()
+        cursor = conn.execute(
+            """
+            UPDATE circleback_items
+            SET status = ?, updated_at = CURRENT_TIMESTAMP
+            WHERE id = ?
+            """,
+            (status, item_id),
+        )
+        self._commit_and_sync(conn)
+        return cursor.rowcount > 0
+
+    def update_circleback_fields(
+        self,
+        item_id: int,
+        priority: int | None = None,
+        circle_back_date: str | None = None,
+        note: str | None = None,
+    ) -> bool:
+        """
+        Update mutable fields on a circle-back item (priority, date, note).
+
+        Only the fields passed (non-None) are updated. To explicitly clear a
+        date, pass the empty string.
+
+        Returns:
+            True if a row was updated, False if not found or nothing to update.
+        """
+        sets: list[str] = []
+        params: list = []
+        if priority is not None:
+            sets.append("priority = ?")
+            params.append(priority)
+        if circle_back_date is not None:
+            sets.append("circle_back_date = ?")
+            params.append(circle_back_date or None)
+        if note is not None:
+            sets.append("note = ?")
+            params.append(note)
+        if not sets:
+            return False
+
+        sets.append("updated_at = CURRENT_TIMESTAMP")
+        params.append(item_id)
+        conn = self._get_connection()
+        cursor = conn.execute(
+            f"UPDATE circleback_items SET {', '.join(sets)} WHERE id = ?",
+            params,
+        )
+        self._commit_and_sync(conn)
+        return cursor.rowcount > 0
+
+    def set_circleback_issue(self, item_id: int, issue_url: str) -> bool:
+        """Record the GitHub issue URL an item was promoted into."""
+        conn = self._get_connection()
+        cursor = conn.execute(
+            """
+            UPDATE circleback_items
+            SET issue_url = ?, status = 'promoted', updated_at = CURRENT_TIMESTAMP
+            WHERE id = ?
+            """,
+            (issue_url, item_id),
+        )
+        self._commit_and_sync(conn)
+        return cursor.rowcount > 0
+
+    def circleback_exists_by_source_ref(self, source: str, source_ref: str) -> bool:
+        """
+        Check whether a circle-back item with this source/source_ref exists.
+
+        Used to dedupe items captured from automated sources so re-running a
+        pipeline doesn't create duplicates.
+        """
+        conn = self._get_connection()
+        row = conn.execute(
+            "SELECT 1 FROM circleback_items WHERE source = ? AND source_ref = ? LIMIT 1",
+            (source, source_ref),
+        ).fetchone()
+        return row is not None
+
+    def delete_circleback_item(self, item_id: int) -> bool:
+        """Delete a circle-back item. Returns True if a row was removed."""
+        conn = self._get_connection()
+        cursor = conn.execute(
+            "DELETE FROM circleback_items WHERE id = ?", (item_id,)
+        )
         self._commit_and_sync(conn)
         return cursor.rowcount > 0
 

--- a/src/typer_cli.py
+++ b/src/typer_cli.py
@@ -21,6 +21,7 @@ notify_app = typer.Typer(help="Notification commands")
 news_app = typer.Typer(help="AI news commands")
 streak_app = typer.Typer(help="Streak tracking commands")
 ideas_app = typer.Typer(help="Project idea generation commands")
+circleback_app = typer.Typer(help="Circle-back: earmark items to revisit later")
 quests_app = typer.Typer(help="Quest management commands")
 achievements_app = typer.Typer(help="Achievement tracking commands")
 routines_app = typer.Typer(help="Claude Code Routines migration commands")
@@ -30,6 +31,7 @@ app.add_typer(notify_app, name="notify")
 app.add_typer(news_app, name="news")
 app.add_typer(streak_app, name="streak")
 app.add_typer(ideas_app, name="ideas")
+app.add_typer(circleback_app, name="circleback")
 app.add_typer(quests_app, name="quests")
 app.add_typer(achievements_app, name="achievements")
 app.add_typer(routines_app, name="routines")
@@ -1834,6 +1836,239 @@ def ideas_sync(
         print(f"  File: {d['total_in_file']} ideas | Database: {d['total_in_db']} ideas")
 
     _output(result, json_output, _human)
+
+
+# ---------------------------------------------------------------------------
+# circleback subcommands
+# ---------------------------------------------------------------------------
+
+
+def _circleback_line(item: dict) -> str:
+    """Format a single circle-back item for human output."""
+    flag = {1: "!!", 2: " !", 3: "  "}.get(item.get("priority"), " !")
+    date_part = f"  (circle back {item['circle_back_date']})" if item.get(
+        "circle_back_date"
+    ) else ""
+    promoted = f"  -> {item['issue_url']}" if item.get("issue_url") else ""
+    return (
+        f"  {flag} #{item['id']}  [{item.get('kind', 'idea')}] "
+        f"{item['content']}{date_part}{promoted}"
+    )
+
+
+@circleback_app.command("add")
+def circleback_add(
+    content: str = typer.Argument(..., help="What to circle back to"),
+    kind: str = typer.Option(
+        "idea", "--kind", help="continue | project | idea"
+    ),
+    priority: str = typer.Option(
+        "medium", "--priority", help="high | medium | low"
+    ),
+    date: Optional[str] = typer.Option(
+        None, "--date", help="Snooze until this date (YYYY-MM-DD)"
+    ),
+    note: Optional[str] = typer.Option(None, "--note", help="Longer context"),
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+):
+    """Earmark an item to revisit later."""
+    from src.circleback import CircleBackError, CircleBackManager
+
+    cm = CircleBackManager()
+    try:
+        item = cm.add(
+            content, kind=kind, priority=priority, circle_back_date=date, note=note
+        )
+    except CircleBackError as exc:
+        if json_output:
+            print(json.dumps({"error": str(exc), "code": 2}))
+        else:
+            print(f"Error: {exc}", file=sys.stderr)
+        raise typer.Exit(2)
+
+    data = {"item": item}
+
+    def _human(d):
+        print("Circle-back item added:")
+        print(_circleback_line(d["item"]))
+
+    _output(data, json_output, _human)
+
+
+@circleback_app.command("list")
+def circleback_list(
+    status: Optional[str] = typer.Option(
+        "open", "--status", help="open | done | promoted | dropped | all"
+    ),
+    kind: Optional[str] = typer.Option(None, "--kind", help="Filter by kind"),
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+):
+    """List circle-back items (open ones by default)."""
+    from src.circleback import CircleBackManager
+
+    cm = CircleBackManager()
+    status_filter = None if status == "all" else status
+    items = cm.list_items(status=status_filter, kind=kind)
+
+    data = {"items": items}
+
+    def _human(d):
+        if not d["items"]:
+            print("No circle-back items.")
+            return
+        print(f"Circle-back items ({len(d['items'])}):\n")
+        for item in d["items"]:
+            print(_circleback_line(item))
+
+    _output(data, json_output, _human)
+
+
+@circleback_app.command("due")
+def circleback_due(
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+):
+    """Show items that are due now (undated or past their circle-back date)."""
+    from src.circleback import CircleBackManager
+
+    cm = CircleBackManager()
+    due = cm.due_items()
+    upcoming = cm.upcoming_items()
+    data = {"due": due, "upcoming_count": len(upcoming)}
+
+    def _human(d):
+        if not d["due"]:
+            print("Nothing due to circle back to right now.")
+        else:
+            print(f"Due to circle back ({len(d['due'])}):\n")
+            for item in d["due"]:
+                print(_circleback_line(item))
+        if d["upcoming_count"]:
+            print(f"\n({d['upcoming_count']} more still snoozed.)")
+
+    _output(data, json_output, _human)
+
+
+@circleback_app.command("done")
+def circleback_done(
+    item_id: int = typer.Argument(..., help="Item ID to mark done"),
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+):
+    """Mark a circle-back item as done."""
+    _circleback_transition(item_id, "mark_done", "done", json_output)
+
+
+@circleback_app.command("drop")
+def circleback_drop(
+    item_id: int = typer.Argument(..., help="Item ID to drop"),
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+):
+    """Drop a circle-back item you no longer want to revisit."""
+    _circleback_transition(item_id, "drop", "dropped", json_output)
+
+
+def _circleback_transition(item_id, method, label, json_output):
+    from src.circleback import CircleBackManager
+
+    cm = CircleBackManager()
+    ok = getattr(cm, method)(item_id)
+    if not ok:
+        if json_output:
+            print(json.dumps({"error": "Item not found", "code": 2}))
+        else:
+            print(f"Circle-back item {item_id} not found.", file=sys.stderr)
+        raise typer.Exit(2)
+
+    data = {"id": item_id, "status": label}
+
+    def _human(d):
+        print(f"Circle-back item #{d['id']} marked {d['status']}.")
+
+    _output(data, json_output, _human)
+
+
+@circleback_app.command("snooze")
+def circleback_snooze(
+    item_id: int = typer.Argument(..., help="Item ID to snooze"),
+    date: str = typer.Argument(..., help="Circle back on this date (YYYY-MM-DD)"),
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+):
+    """Push an item to a future date."""
+    from src.circleback import CircleBackError, CircleBackManager
+
+    cm = CircleBackManager()
+    try:
+        ok = cm.snooze(item_id, date)
+    except CircleBackError as exc:
+        if json_output:
+            print(json.dumps({"error": str(exc), "code": 2}))
+        else:
+            print(f"Error: {exc}", file=sys.stderr)
+        raise typer.Exit(2)
+
+    if not ok:
+        if json_output:
+            print(json.dumps({"error": "Item not found", "code": 2}))
+        else:
+            print(f"Circle-back item {item_id} not found.", file=sys.stderr)
+        raise typer.Exit(2)
+
+    item = cm.get(item_id)
+    data = {"item": item}
+
+    def _human(d):
+        print(f"Circle-back item #{item_id} snoozed until {date}.")
+
+    _output(data, json_output, _human)
+
+
+@circleback_app.command("promote-to-issue")
+def circleback_promote_to_issue(
+    item_id: int = typer.Argument(..., help="Item ID to promote"),
+    repo: Optional[str] = typer.Option(
+        None, "--repo", help="Target repo owner/name (defaults to cwd repo)"
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+):
+    """Create a GitHub issue from a circle-back item and mark it promoted."""
+    from src.circleback import CircleBackManager
+
+    cm = CircleBackManager()
+    result = cm.promote_to_issue(item_id, repo=repo)
+    if not result.get("ok"):
+        if json_output:
+            print(json.dumps({"error": result.get("error"), "code": 2}))
+        else:
+            print(f"Error: {result.get('error')}", file=sys.stderr)
+        raise typer.Exit(2)
+
+    def _human(d):
+        print(f"Circle-back item #{item_id} promoted to issue:")
+        print(f"  {d['issue_url']}")
+
+    _output(result, json_output, _human)
+
+
+@circleback_app.command("context")
+def circleback_context(
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+):
+    """Emit due circle-back items as priority context for the agent.
+
+    Intended for the nightly /newsandideas pipeline: run this first so the
+    agent sees what you've already flagged as important before proposing new
+    work.
+    """
+    from src.circleback import CircleBackManager
+
+    cm = CircleBackManager()
+    data = cm.build_agent_context()
+
+    def _human(d):
+        print(d["summary"])
+        for item in d["due"]:
+            print(_circleback_line(item))
+
+    _output(data, json_output, _human)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_circleback.py
+++ b/tests/test_circleback.py
@@ -1,0 +1,178 @@
+"""Tests for the circle-back system."""
+
+import tempfile
+from datetime import date, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.circleback import CircleBackError, CircleBackManager, parse_priority
+from src.storage import CommitStorage
+
+
+@pytest.fixture
+def temp_db():
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = Path(f.name)
+    yield db_path
+    if db_path.exists():
+        db_path.unlink()
+
+
+@pytest.fixture
+def storage(temp_db):
+    return CommitStorage(temp_db)
+
+
+@pytest.fixture
+def cm(storage):
+    return CircleBackManager(storage)
+
+
+class TestStorage:
+    def test_create_and_get(self, storage):
+        item_id = storage.create_circleback_item("Revisit caching layer")
+        item = storage.get_circleback_item(item_id)
+        assert item["content"] == "Revisit caching layer"
+        assert item["status"] == "open"
+        assert item["kind"] == "idea"
+        assert item["priority"] == 2
+
+    def test_dedup_helper(self, storage):
+        storage.create_circleback_item(
+            "x", source="newsandideas", source_ref="ref-1"
+        )
+        assert storage.circleback_exists_by_source_ref("newsandideas", "ref-1")
+        assert not storage.circleback_exists_by_source_ref("newsandideas", "ref-2")
+
+    def test_ordering_by_priority_then_date(self, storage):
+        storage.create_circleback_item("low", priority=3)
+        storage.create_circleback_item(
+            "high-soon", priority=1, circle_back_date="2026-01-01"
+        )
+        storage.create_circleback_item(
+            "high-later", priority=1, circle_back_date="2026-12-01"
+        )
+        items = storage.get_circleback_items()
+        assert [i["content"] for i in items][:3] == [
+            "high-soon",
+            "high-later",
+            "low",
+        ]
+
+    def test_update_fields_clear_date(self, storage):
+        item_id = storage.create_circleback_item("x", circle_back_date="2026-06-01")
+        assert storage.update_circleback_fields(item_id, circle_back_date="")
+        assert storage.get_circleback_item(item_id)["circle_back_date"] is None
+
+    def test_set_issue_marks_promoted(self, storage):
+        item_id = storage.create_circleback_item("x")
+        storage.set_circleback_issue(item_id, "https://github.com/o/r/issues/5")
+        item = storage.get_circleback_item(item_id)
+        assert item["status"] == "promoted"
+        assert item["issue_url"].endswith("/issues/5")
+
+
+class TestParsePriority:
+    def test_words_and_ints(self):
+        assert parse_priority("high") == 1
+        assert parse_priority("LOW") == 3
+        assert parse_priority(2) == 2
+        assert parse_priority("3") == 3
+        assert parse_priority(None) == 2
+
+    def test_invalid(self):
+        with pytest.raises(CircleBackError):
+            parse_priority("urgent")
+        with pytest.raises(CircleBackError):
+            parse_priority(9)
+
+
+class TestManager:
+    def test_add_validates_kind(self, cm):
+        with pytest.raises(CircleBackError):
+            cm.add("x", kind="bogus")
+
+    def test_add_validates_date(self, cm):
+        with pytest.raises(CircleBackError):
+            cm.add("x", circle_back_date="June 1st")
+
+    def test_add_rejects_empty(self, cm):
+        with pytest.raises(CircleBackError):
+            cm.add("   ")
+
+    def test_add_decorates_priority_label(self, cm):
+        item = cm.add("x", priority="high")
+        assert item["priority"] == 1
+        assert item["priority_label"] == "high"
+
+    def test_add_dedups_on_source_ref(self, cm):
+        a = cm.add("x", source="newsandideas", source_ref="r1")
+        b = cm.add("x again", source="newsandideas", source_ref="r1")
+        assert a["id"] == b["id"]
+        assert len(cm.list_items()) == 1
+
+    def test_due_includes_undated_and_past(self, cm):
+        yesterday = (date.today() - timedelta(days=1)).isoformat()
+        tomorrow = (date.today() + timedelta(days=1)).isoformat()
+        cm.add("undated")
+        cm.add("past", circle_back_date=yesterday)
+        cm.add("future", circle_back_date=tomorrow)
+        due = {i["content"] for i in cm.due_items()}
+        assert due == {"undated", "past"}
+        upcoming = {i["content"] for i in cm.upcoming_items()}
+        assert upcoming == {"future"}
+
+    def test_snooze_then_not_due(self, cm):
+        item = cm.add("x")
+        future = (date.today() + timedelta(days=5)).isoformat()
+        cm.snooze(item["id"], future)
+        assert cm.due_items() == []
+        assert len(cm.upcoming_items()) == 1
+
+    def test_done_and_drop(self, cm):
+        a = cm.add("a")
+        b = cm.add("b")
+        cm.mark_done(a["id"])
+        cm.drop(b["id"])
+        assert cm.list_items(status="open") == []
+        assert len(cm.list_items(status="done")) == 1
+        assert len(cm.list_items(status="dropped")) == 1
+
+    def test_build_agent_context(self, cm):
+        cm.add("continue this", kind="continue", priority="high")
+        cm.add(
+            "future",
+            circle_back_date=(date.today() + timedelta(days=3)).isoformat(),
+        )
+        ctx = cm.build_agent_context()
+        assert ctx["due_count"] == 1
+        assert ctx["upcoming_count"] == 1
+        assert ctx["by_kind"]["continue"][0]["content"] == "continue this"
+        assert "high-priority" in ctx["summary"]
+
+    def test_promote_to_issue_success(self, cm):
+        item = cm.add("ship it", note="some context")
+        fake = {"created": True, "url": "https://github.com/o/r/issues/9"}
+        with patch("src.gh_issues.create_issue", return_value=fake) as mock_create:
+            result = cm.promote_to_issue(item["id"], repo="o/r")
+        assert result["ok"]
+        assert result["issue_url"].endswith("/issues/9")
+        # body should carry the note + metadata
+        _, kwargs = mock_create.call_args
+        assert "some context" in kwargs["body"]
+        assert cm.get(item["id"])["status"] == "promoted"
+
+    def test_promote_to_issue_failure_keeps_open(self, cm):
+        item = cm.add("nope")
+        fake = {"created": False, "error": "gh not found"}
+        with patch("src.gh_issues.create_issue", return_value=fake):
+            result = cm.promote_to_issue(item["id"])
+        assert not result["ok"]
+        assert cm.get(item["id"])["status"] == "open"
+
+    def test_promote_missing_item(self, cm):
+        result = cm.promote_to_issue(999)
+        assert not result["ok"]
+        assert "not found" in result["error"]

--- a/tests/test_typer_cli.py
+++ b/tests/test_typer_cli.py
@@ -824,3 +824,95 @@ class TestIdeasSync:
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data["added"] == 2
+
+
+# ---------------------------------------------------------------------------
+# circleback
+# ---------------------------------------------------------------------------
+
+
+class TestCircleBack:
+    @pytest.fixture(autouse=True)
+    def _tmp_db(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("CODE_DAILY_DB_PATH", str(tmp_path / "cb.db"))
+        monkeypatch.delenv("TURSO_DATABASE_URL", raising=False)
+
+    def test_add_and_list_json(self):
+        result = runner.invoke(
+            app,
+            ["circleback", "add", "Revisit caching", "--kind", "continue",
+             "--priority", "high", "--json"],
+        )
+        assert result.exit_code == 0
+        item = json.loads(result.output)["item"]
+        assert item["content"] == "Revisit caching"
+        assert item["priority"] == 1
+        assert item["kind"] == "continue"
+
+        result = runner.invoke(app, ["circleback", "list", "--json"])
+        assert result.exit_code == 0
+        items = json.loads(result.output)["items"]
+        assert len(items) == 1
+
+    def test_add_invalid_kind_exits(self):
+        result = runner.invoke(
+            app, ["circleback", "add", "x", "--kind", "bogus", "--json"]
+        )
+        assert result.exit_code == 2
+        assert "error" in json.loads(result.output)
+
+    def test_due_excludes_future_snoozed(self):
+        runner.invoke(app, ["circleback", "add", "now-item", "--json"])
+        runner.invoke(
+            app, ["circleback", "add", "later", "--date", "2099-01-01", "--json"]
+        )
+        result = runner.invoke(app, ["circleback", "due", "--json"])
+        data = json.loads(result.output)
+        assert [i["content"] for i in data["due"]] == ["now-item"]
+        assert data["upcoming_count"] == 1
+
+    def test_done_transitions(self):
+        add = runner.invoke(app, ["circleback", "add", "x", "--json"])
+        item_id = json.loads(add.output)["item"]["id"]
+        result = runner.invoke(app, ["circleback", "done", str(item_id), "--json"])
+        assert result.exit_code == 0
+        assert json.loads(result.output)["status"] == "done"
+        # no longer in open list
+        lst = runner.invoke(app, ["circleback", "list", "--json"])
+        assert json.loads(lst.output)["items"] == []
+
+    def test_done_missing_exits(self):
+        result = runner.invoke(app, ["circleback", "done", "999", "--json"])
+        assert result.exit_code == 2
+
+    def test_snooze(self):
+        add = runner.invoke(app, ["circleback", "add", "x", "--json"])
+        item_id = json.loads(add.output)["item"]["id"]
+        result = runner.invoke(
+            app, ["circleback", "snooze", str(item_id), "2099-05-05", "--json"]
+        )
+        assert result.exit_code == 0
+        assert json.loads(result.output)["item"]["circle_back_date"] == "2099-05-05"
+
+    def test_context_command(self):
+        runner.invoke(
+            app,
+            ["circleback", "add", "important", "--priority", "high", "--json"],
+        )
+        result = runner.invoke(app, ["circleback", "context", "--json"])
+        data = json.loads(result.output)
+        assert data["due_count"] == 1
+        assert "high-priority" in data["summary"]
+
+    def test_promote_to_issue(self):
+        add = runner.invoke(app, ["circleback", "add", "ship", "--json"])
+        item_id = json.loads(add.output)["item"]["id"]
+        fake = {"created": True, "url": "https://github.com/o/r/issues/3"}
+        with patch("src.gh_issues.create_issue", return_value=fake):
+            result = runner.invoke(
+                app,
+                ["circleback", "promote-to-issue", str(item_id), "--repo", "o/r",
+                 "--json"],
+            )
+        assert result.exit_code == 0
+        assert json.loads(result.output)["issue_url"].endswith("/issues/3")


### PR DESCRIPTION
## What

Adds a dedicated `circleback` system for flagging items to circle back to — work you started and mean to continue, new project ideas worth retaining, or overflow surfaced during a `/newsandideas` run that deserves more than a fleeting mention.

It's deliberately distinct from the two adjacent systems:

- **`quests`** = the auto-discovered work queue
- **`ideas`** = the IDEAS.md running list
- **`circleback`** (new) = earmarked items with an optional **snooze-until date** *and* an explicit **priority** that signals to the agent what *you* think is important

## Why

Running `/newsandideas` often surfaces more good work than fits in one session. Today there's nowhere to park "do this, but later" or "great idea, keep it" without either dropping it or prematurely turning it into a GitHub issue. This gives those items a home, a date to resurface on, and a priority the agent reads back on the next run.

## The pieces

- **`circleback_items` table** (`storage.py`) — `content`, `note`, `kind` (`continue`/`project`/`idea`), `priority` (high/med/low), `circle_back_date`, `status` (`open → done | dropped | promoted`), `source`/`source_ref` dedup, `issue_url`. Plus CRUD methods mirroring the quests/ideas patterns.
- **`src/circleback.py`** — `CircleBackManager`: add/list/due/upcoming/snooze/done/drop, due-date + priority sorting, `promote_to_issue` bridge, and `build_agent_context()` for pipeline surfacing.
- **`gh_issues.create_issue()`** — `gh issue create` wrapper for the promote-to-issue bridge.
- **CLI** — `circleback add | list | due | done | drop | snooze | promote-to-issue | context` (all `--json`).
- **Docs** — `CLAUDE.md` command reference + an Agent Workflow section wiring circleback into the nightly `/newsandideas` run: load priorities at the start (`circleback context`), capture overflow at the end (`circleback add`).

## Usage

```
code-daily circleback add "Continue streak insights refactor" --kind continue --priority high
code-daily circleback add "Obsidian graph exporter" --kind project --date 2026-07-01
code-daily circleback due          # actionable now; snoozed items stay hidden until due
code-daily circleback promote-to-issue 1 --repo michaelpawlus/code-daily
```

## Tests

New unit + CLI coverage in `tests/test_circleback.py` and `tests/test_typer_cli.py`. Full suite: **739 passed, 1 failed** — the single failure is a pre-existing, environmental issue in `test_launchpad.py` (git commit object signing fails in its temp repo), confirmed to fail identically with these changes stashed. Nothing in this PR touches launchpad.

## Notes

- Named `circleback` (not `todo`) to match the "circle back" framing and avoid colliding with the existing `todo_scanner` (which scans `TODO`/`FIXME` comments).
- No dashboard panel in this PR (deferred by request). The `circleback context --json` / `due --json` payloads are ready to drop into a panel later.

https://claude.ai/code/session_01PNMZ7CLpXGHs894ug3qQmC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PNMZ7CLpXGHs894ug3qQmC)_